### PR TITLE
don't link libc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,6 @@ impl_from_c_int!(PrctlTiming);
 impl_from_c_int!(PrctlTsc);
 impl_from_c_int!(PrctlUnalign);
 
-#[link(name="c")]
 extern {
     fn prctl(option: c_int, arg2: c_ulong, arg3: c_ulong, arg4: c_ulong, arg5: c_ulong) -> c_int;
 }


### PR DESCRIPTION
It is not necessary to link libc manually, as libc is already
contained in `liblibc.rlib` which gets linked in automatically.

This link annotation is harmful as in static situations (where
target_feature="crt-static") it will force linking the dynamic libc,
producing chimera binaries or breaking the build entirely.