### PR TITLE
Do not require default features in nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ name = "prctl"
 doctest = false
 
 [dependencies]
-nix = "*"
+nix = { version = "*", default-features = false }
 libc = "*"


### PR DESCRIPTION
This library does not require any features to be enabled in nix to work properly.

The nix crate has a lot of features enabled in its default, which can cause problems if a downstream user does not want those enabled. I suspect nix was less feature-filled when this crate was last released 7 years ago, but now nix is quite large.